### PR TITLE
Resolve links for strongly typed models

### DIFF
--- a/KenticoCloud.Delivery.Tests/ContentLinkResolverTests.cs
+++ b/KenticoCloud.Delivery.Tests/ContentLinkResolverTests.cs
@@ -107,20 +107,16 @@ namespace KenticoCloud.Delivery.Tests
             Assert.AreEqual("Learn <a href=\"http://example.org/article/about_us/CID-about-us\" data-item-id=\"CID\">more</a>.", result);
         }
 
-        public class Office
-        {
-            public string AboutTheOffce { get; set; }
-        }
-
         [Test]
         public void ResolveLinksInStronglyTypedModel()
         {
-            // TODO: Use test project rather than sandbox
             var client = new DeliveryClient("e1167a11-75af-4a08-ad84-0582b463b010");
             client.ContentLinkUrlResolver = new CustomContentLinkUrlResolver();
 
+            string expected = "<p><a href=\"https://en.wikipedia.org/wiki/Brno\">Brno</a> office is very far from <a data-item-id=\"ee82db8c-de06-4992-9561-1fc642056c2b\" href=\"http://example.org/melbourne-office\">Melbourne</a> office.</p>";
             var item = client.GetItemAsync<Office>("brno_office").Result.Item;
-            Assert.AreEqual("", item.AboutTheOffce);
+
+            Assert.AreEqual(expected, item.AboutTheOffice);
         }
 
         private string ResolveContentLinks(string text)

--- a/KenticoCloud.Delivery.Tests/ContentLinkResolverTests.cs
+++ b/KenticoCloud.Delivery.Tests/ContentLinkResolverTests.cs
@@ -107,6 +107,22 @@ namespace KenticoCloud.Delivery.Tests
             Assert.AreEqual("Learn <a href=\"http://example.org/article/about_us/CID-about-us\" data-item-id=\"CID\">more</a>.", result);
         }
 
+        public class Office
+        {
+            public string AboutTheOffce { get; set; }
+        }
+
+        [Test]
+        public void ResolveLinksInStronglyTypedModel()
+        {
+            // TODO: Use test project rather than sandbox
+            var client = new DeliveryClient("e1167a11-75af-4a08-ad84-0582b463b010");
+            client.ContentLinkUrlResolver = new CustomContentLinkUrlResolver();
+
+            var item = client.GetItemAsync<Office>("brno_office").Result.Item;
+            Assert.AreEqual("", item.AboutTheOffce);
+        }
+
         private string ResolveContentLinks(string text)
         {
             var linkUrlResolver = new CustomContentLinkUrlResolver();

--- a/KenticoCloud.Delivery.Tests/Models/Office.cs
+++ b/KenticoCloud.Delivery.Tests/Models/Office.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace KenticoCloud.Delivery.Tests
+{
+    public class Office
+    {
+        public string AboutTheOffice { get; set; }
+    }
+}

--- a/KenticoCloud.Delivery/CodeFirst/CodeFirstModelProvider.cs
+++ b/KenticoCloud.Delivery/CodeFirst/CodeFirstModelProvider.cs
@@ -84,10 +84,21 @@ namespace KenticoCloud.Delivery
                             ?.FirstOrDefault(p => PropertyMapper.IsMatch(property, p.Name, system?.Type))
                             ?.FirstOrDefault()["value"];
 
-                        if (propertyType == typeof(IEnumerable<MultipleChoiceOption>)
+                        if (propertyType == typeof(string))
+                        {
+                            var links = ((JObject)propValue?.Parent?.Parent)?.Property("links")?.Value;
+
+                            // Handle rich_text link resolution
+                            if (links != null && propValue != null && _client.ContentLinkResolver != null)
+                            {
+                                value = _client.ContentLinkResolver.ResolveContentLinks(propValue?.ToObject<string>(), links);
+                            }
+
+                            value = propValue?.ToObject(propertyType);
+                        }
+                        else if (propertyType == typeof(IEnumerable<MultipleChoiceOption>)
                                  || propertyType == typeof(IEnumerable<Asset>)
                                  || propertyType == typeof(IEnumerable<TaxonomyTerm>)
-                                 || propertyType == typeof(string)
                                  || propertyType.GetTypeInfo().IsValueType)
                         {
                             // Handle non-hierarchical fields
@@ -95,8 +106,7 @@ namespace KenticoCloud.Delivery
                         }
                         else if (propertyType.GetTypeInfo().IsGenericType
                             && ((propertyType.GetInterfaces().Any(gt => gt.GetTypeInfo().IsGenericType && gt.GetTypeInfo().GetGenericTypeDefinition() == typeof(ICollection<>)) && propertyType.GetTypeInfo().IsClass)
-                            || propertyType.GetGenericTypeDefinition() == typeof(IEnumerable<>))
-)
+                            || propertyType.GetGenericTypeDefinition() == typeof(IEnumerable<>)))
                         {
                             // Handle modular content
                             var contentItemCodenames = propValue?.ToObject<IEnumerable<string>>();

--- a/KenticoCloud.Delivery/CodeFirst/CodeFirstModelProvider.cs
+++ b/KenticoCloud.Delivery/CodeFirst/CodeFirstModelProvider.cs
@@ -93,8 +93,10 @@ namespace KenticoCloud.Delivery
                             {
                                 value = _client.ContentLinkResolver.ResolveContentLinks(propValue?.ToObject<string>(), links);
                             }
-
-                            value = propValue?.ToObject(propertyType);
+                            else
+                            {
+                                value = propValue?.ToObject(propertyType);
+                            }
                         }
                         else if (propertyType == typeof(IEnumerable<MultipleChoiceOption>)
                                  || propertyType == typeof(IEnumerable<Asset>)


### PR DESCRIPTION
This should fix #18 

Hopefully I got it right :) 

Before it's merged, we should probably store content items used in this test in Test project rather than in my sandbox project.
