### PR TITLE
Fix sitemap locations property loading

### DIFF
--- a/KenticoCloud.Delivery/CodeFirst/CodeFirstModelProvider.cs
+++ b/KenticoCloud.Delivery/CodeFirst/CodeFirstModelProvider.cs
@@ -51,7 +51,8 @@ namespace KenticoCloud.Delivery
         internal object GetContentItemModel(Type t, JToken item, JToken modularContent, Dictionary<string, object> processedItems = null)
         {
             processedItems = processedItems ?? new Dictionary<string, object>();
-            ContentItemSystemAttributes system = (ContentItemSystemAttributes)((JObject)item["system"]).ToObject(typeof(ContentItemSystemAttributes));
+            var system = item["system"].ToObject<ContentItemSystemAttributes>();
+
             if (t == typeof(object))
             {
                 // Try to find a specific type

--- a/KenticoCloud.Delivery/Models/Asset.cs
+++ b/KenticoCloud.Delivery/Models/Asset.cs
@@ -10,25 +10,29 @@ namespace KenticoCloud.Delivery
         /// <summary>
         /// Gets the name of the asset.
         /// </summary>
+        [JsonProperty("name")]
         public string Name { get; }
 
         /// <summary>
         /// Gets the media type of the asset, for example "image/jpeg".
         /// </summary>
+        [JsonProperty("type")]
         public string Type { get; }
 
         /// <summary>
         /// Gets the asset size in bytes.
         /// </summary>
+        [JsonProperty("size")]
         public int Size { get; }
 
         /// <summary>
         /// Gets the URL of the asset.
         /// </summary>
+        [JsonProperty("url")]
         public string Url { get; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Asset"/> class with the specified JSON data.
+        /// Initializes a new instance of the <see cref="Asset"/> class.
         /// </summary>
         [JsonConstructor]
         internal Asset(string name, string type, int size, string url)

--- a/KenticoCloud.Delivery/Models/Item/ContentItem.cs
+++ b/KenticoCloud.Delivery/Models/Item/ContentItem.cs
@@ -22,7 +22,7 @@ namespace KenticoCloud.Delivery
         /// </summary>
         public ContentItemSystemAttributes System
         {
-            get { return _system ?? (_system = new ContentItemSystemAttributes(_source["system"])); }
+            get { return _system ?? (_system = _source["system"].ToObject<ContentItemSystemAttributes>()); }
         }
 
         /// <summary>

--- a/KenticoCloud.Delivery/Models/Item/ContentItemSystemAttributes.cs
+++ b/KenticoCloud.Delivery/Models/Item/ContentItemSystemAttributes.cs
@@ -1,8 +1,6 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
 
 namespace KenticoCloud.Delivery
 {
@@ -14,42 +12,42 @@ namespace KenticoCloud.Delivery
         /// <summary>
         /// Gets the identifier of the content item.
         /// </summary>
+        [JsonProperty("id")]
         public string Id { get; }
 
         /// <summary>
         /// Gets the name of the content item.
         /// </summary>
+        [JsonProperty("name")]
         public string Name { get; }
 
         /// <summary>
         /// Gets the codename of the content item.
         /// </summary>
+        [JsonProperty("codename")]
         public string Codename { get; }
 
         /// <summary>
         /// Gets the codename of the content type, for example "article".
         /// </summary>
+        [JsonProperty("type")]
         public string Type { get; }
 
         /// <summary>
         /// Gets a list of codenames of sitemap items to which the content item is assigned.
         /// </summary>
+        [JsonProperty("sitemap_locations")]
         public IReadOnlyList<string> SitemapLocation { get; }
 
         /// <summary>
         /// Gets the time the content item was last modified.
         /// </summary>
+        [JsonProperty("last_modified")]
         public DateTime LastModified { get; set; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ContentItemSystemAttributes"/> class with the specified JSON data.
+        /// Initializes a new instance of the <see cref="ContentItemSystemAttributes"/> class.
         /// </summary>
-        /// <param name="source">The JSON data to deserialize.</param>
-        internal ContentItemSystemAttributes(JToken source)
-            : this(source["id"].ToString(), source["name"].ToString(), source["codename"].ToString(), source["type"].ToString(), ((JArray)source["sitemap_locations"]).Values<string>().ToList().AsReadOnly(), source["last_modified"].Value<DateTime>())
-        {
-        }
-
         [JsonConstructor]
         internal ContentItemSystemAttributes(string id, string name, string codename, string type, IReadOnlyList<string> sitemapLocation, DateTime lastModified)
         {

--- a/KenticoCloud.Delivery/Models/MultipleChoiceOption.cs
+++ b/KenticoCloud.Delivery/Models/MultipleChoiceOption.cs
@@ -10,15 +10,17 @@ namespace KenticoCloud.Delivery
         /// <summary>
         /// Gets the name of the selected option.
         /// </summary>
+        [JsonProperty("name")]
         public string Name { get; }
 
         /// <summary>
         /// Gets the codename of the selected option.
         /// </summary>
+        [JsonProperty("codename")]
         public string Codename { get; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="MultipleChoiceOption"/> class with the specified JSON data.
+        /// Initializes a new instance of the <see cref="MultipleChoiceOption"/> class.
         /// </summary>
         [JsonConstructor]
         internal MultipleChoiceOption(string name, string codename)

--- a/KenticoCloud.Delivery/Models/TaxonomyTerm.cs
+++ b/KenticoCloud.Delivery/Models/TaxonomyTerm.cs
@@ -1,6 +1,4 @@
 ﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using System;
 
 namespace KenticoCloud.Delivery
 {
@@ -12,15 +10,17 @@ namespace KenticoCloud.Delivery
         /// <summary>
         /// Gets the name of the taxonomy term.
         /// </summary>
+        [JsonProperty("name")]
         public string Name { get; }
 
         /// <summary>
         /// Gets the codename of the taxonomy term.
         /// </summary>
+        [JsonProperty("codename")]
         public string Codename { get; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="TaxonomyTerm"/> class with the specified JSON data.
+        /// Initializes a new instance of the <see cref="TaxonomyTerm"/> class.
         /// </summary>
         [JsonConstructor]
         internal TaxonomyTerm(string name, string codename)

--- a/KenticoCloud.Delivery/Models/Type/ContentTypeSystemAttributes.cs
+++ b/KenticoCloud.Delivery/Models/Type/ContentTypeSystemAttributes.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using System;
 
 namespace KenticoCloud.Delivery
@@ -12,34 +11,37 @@ namespace KenticoCloud.Delivery
         /// <summary>
         /// Gets the identifier of the content type.
         /// </summary>
+        [JsonProperty("id")]
         public string Id { get; }
 
         /// <summary>
         /// Gets the name of the content type.
         /// </summary>
+        [JsonProperty("name")]
         public string Name { get; }
 
         /// <summary>
         /// Gets the codename of the content type.
         /// </summary>
+        [JsonProperty("codename")]
         public string Codename { get; }
 
         /// <summary>
         /// Gets the time the content type was last modified.
         /// </summary>
+        [JsonProperty("last_modified")]
         public DateTime LastModified { get; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ContentTypeSystemAttributes"/> class with the specified JSON data.
+        /// Initializes a new instance of the <see cref="ContentTypeSystemAttributes"/> class.
         /// </summary>
-        /// <param name="source">The JSON data to deserialize.</param>
         [JsonConstructor]
-        internal ContentTypeSystemAttributes(string id, string name, string codename, DateTime last_modified)
+        internal ContentTypeSystemAttributes(string id, string name, string codename, DateTime lastModified)
         {
             Id = id;
             Name = name;
             Codename = codename;
-            LastModified = last_modified;
+            LastModified = lastModified;
         }
     }
 }

--- a/KenticoCloud.Delivery/Models/Type/Element/MultipleChoiceContentElementOption.cs
+++ b/KenticoCloud.Delivery/Models/Type/Element/MultipleChoiceContentElementOption.cs
@@ -10,6 +10,7 @@ namespace KenticoCloud.Delivery
         /// <summary>
         /// Gets the name of the option.
         /// </summary>
+        [JsonProperty("name")]
         public string Name
         {
             get;
@@ -18,6 +19,7 @@ namespace KenticoCloud.Delivery
         /// <summary>
         /// Gets the codename of the option.
         /// </summary>
+        [JsonProperty("codename")]
         public string Codename
         {
             get;


### PR DESCRIPTION
Loading `ContentItemSystemAttributes` had a bug. Property `SitemapLocations` wasn't loaded because it's name wasn't found by Newtonsoft.Json (`sitemapLocations` in constructor vs. `sitemap_locations` in JSON).

I've fixed it by annotating properties with `JsonProperty` attribute. I've also added this attribute to all other models. It should remind us that property name and json name might not match.
