### PR TITLE
Added description property to Asset model

### DIFF
--- a/KenticoCloud.Delivery/Models/Asset.cs
+++ b/KenticoCloud.Delivery/Models/Asset.cs
@@ -13,6 +13,12 @@ namespace KenticoCloud.Delivery
         [JsonProperty("name")]
         public string Name { get; }
 
+		/// <summary>
+		/// Gets the description of the asset.
+		/// </summary>
+		[JsonProperty("description")]
+	    public string Description { get; }
+
         /// <summary>
         /// Gets the media type of the asset, for example "image/jpeg".
         /// </summary>


### PR DESCRIPTION
Implements @ChristopherJennings request #40

I'm wanting to add an assertion after [Line208](https://github.com/Kentico/delivery-sdk-net/blob/master/KenticoCloud.Delivery.Tests/DeliveryClientTests.cs#L208) in the ```DeliveryClientTests.cs``` file

But ```item.AssetField.First().Description``` property appears to be ```null``` for project with sandbox id ```e1167a11-75af-4a08-ad84-0582b463b010```

**Edit** looks like I messed up indentation, will update indentation to spaces