### PR TITLE
Fixes #99 - Add type filter only if missing

### DIFF
--- a/KenticoCloud.Delivery.Tests/QueryParameters/ContentTypeExtractorTests.cs
+++ b/KenticoCloud.Delivery.Tests/QueryParameters/ContentTypeExtractorTests.cs
@@ -6,6 +6,8 @@ namespace KenticoCloud.Delivery.Tests.QueryParameters
 {
     public class ContentTypeExtractorTests
     {
+        private const string CONTENT_TYPE_CODENAME = "SomeContentType";
+
         private ContentTypeExtractor _extractor;
 
         public ContentTypeExtractorTests()
@@ -15,7 +17,7 @@ namespace KenticoCloud.Delivery.Tests.QueryParameters
 
         private class TypeWithContentTypeCodename
         {
-            public const string Codename = "SomeContentType";
+            public const string Codename = CONTENT_TYPE_CODENAME;
         }
 
         [Fact]
@@ -115,6 +117,17 @@ namespace KenticoCloud.Delivery.Tests.QueryParameters
 
             Assert.Single(enhancedParams);
             Assert.True(enhancedParams.Find(x => x.GetQueryStringParameter() == $"system.type=TypeWithoutContentTypeCodename") == null);
+        }
+
+        [Fact]
+        public void ExtractParameters_WhenGivenTypeWithCodenameAndExistingTypeParameter_DoesNotAddCodenameToParams()
+        {
+            var existingParams = new List<IQueryParameter>() { new EqualsFilter("system.type", CONTENT_TYPE_CODENAME) };
+
+            var enhancedParams = new List<IQueryParameter>(_extractor.ExtractParameters<TypeWithContentTypeCodename>(existingParams));
+
+            Assert.Single(enhancedParams);
+            Assert.True(enhancedParams.Find(x => x.GetQueryStringParameter() == $"system.type={CONTENT_TYPE_CODENAME}") != null);
         }
     }
 }

--- a/KenticoCloud.Delivery.Tests/QueryParameters/ContentTypeExtractorTests.cs
+++ b/KenticoCloud.Delivery.Tests/QueryParameters/ContentTypeExtractorTests.cs
@@ -48,7 +48,7 @@ namespace KenticoCloud.Delivery.Tests.QueryParameters
             {
                 get
                 {
-                    return "SomeContentType";
+                    return CONTENT_TYPE_CODENAME;
                 }
             }
         }
@@ -96,7 +96,7 @@ namespace KenticoCloud.Delivery.Tests.QueryParameters
             var enhancedParams = new List<IQueryParameter>(_extractor.ExtractParameters<TypeWithContentTypeCodename>(existingParams));
 
             Assert.Equal(2, enhancedParams.Count);
-            Assert.True(enhancedParams.Find(x => x.GetQueryStringParameter() == $"system.type=SomeContentType") != null);
+            Assert.True(enhancedParams.Find(x => x.GetQueryStringParameter() == $"system.type={CONTENT_TYPE_CODENAME}") != null);
         }
 
         [Fact]
@@ -105,7 +105,7 @@ namespace KenticoCloud.Delivery.Tests.QueryParameters
             var enhancedParams = new List<IQueryParameter>(_extractor.ExtractParameters<TypeWithContentTypeCodename>());
 
             Assert.Single(enhancedParams);
-            Assert.True(enhancedParams.Find(x => x.GetQueryStringParameter() == $"system.type=SomeContentType") != null);
+            Assert.True(enhancedParams.Find(x => x.GetQueryStringParameter() == $"system.type={CONTENT_TYPE_CODENAME}") != null);
         }
 
         [Fact]

--- a/KenticoCloud.Delivery/QueryParameters/Utilities/ContentTypeExtractor.cs
+++ b/KenticoCloud.Delivery/QueryParameters/Utilities/ContentTypeExtractor.cs
@@ -9,14 +9,23 @@ namespace KenticoCloud.Delivery.QueryParameters.Utilities
     {
         internal IEnumerable<IQueryParameter> ExtractParameters<T>(IEnumerable<IQueryParameter> parameters = null)
         {
-            var contentTypeCodenameRetrieved = TryGetContentTypeCodename(typeof(T), out string contentTypeCodename);
             var enhancedParameters = parameters != null ? new List<IQueryParameter>(parameters) : new List<IQueryParameter>();
-
-            if (contentTypeCodenameRetrieved && (parameters == null || !parameters.Any(p => p.GetType() == typeof(EqualsFilter) && (p as EqualsFilter).ElementOrAttributePath.Equals("system.type", StringComparison.Ordinal))))
+            
+            if (!IsAlreadyInParameters(parameters) && TryGetContentTypeCodename(typeof(T), out string contentTypeCodename))
             {
                 enhancedParameters.Add(new EqualsFilter("system.type", contentTypeCodename));
             }
             return enhancedParameters;
+        }
+
+        private bool IsAlreadyInParameters(IEnumerable<IQueryParameter> parameters)
+        {
+            var typeFilterExists = parameters?
+                .OfType<EqualsFilter>()
+                .Any(filter => filter
+                    .ElementOrAttributePath
+                    .Equals("system.type", StringComparison.Ordinal));
+            return typeFilterExists ?? false;
         }
 
         internal bool TryGetContentTypeCodename(Type contentType, out string codename)

--- a/KenticoCloud.Delivery/QueryParameters/Utilities/ContentTypeExtractor.cs
+++ b/KenticoCloud.Delivery/QueryParameters/Utilities/ContentTypeExtractor.cs
@@ -12,7 +12,7 @@ namespace KenticoCloud.Delivery.QueryParameters.Utilities
             var contentTypeCodenameRetrieved = TryGetContentTypeCodename(typeof(T), out string contentTypeCodename);
             var enhancedParameters = parameters != null ? new List<IQueryParameter>(parameters) : new List<IQueryParameter>();
 
-            if (contentTypeCodenameRetrieved)
+            if (contentTypeCodenameRetrieved && (parameters == null || !parameters.Any(p => p.GetType() == typeof(EqualsFilter) && (p as EqualsFilter).ElementOrAttributePath.Equals("system.type", StringComparison.Ordinal))))
             {
                 enhancedParameters.Add(new EqualsFilter("system.type", contentTypeCodename));
             }
@@ -23,12 +23,15 @@ namespace KenticoCloud.Delivery.QueryParameters.Utilities
         {
             var fields = contentType.GetFields(BindingFlags.Static | BindingFlags.Public);
             string codenameField = "Codename";
+
             if (fields.Any(field => field.Name == codenameField))
             {
                 codename = (string)contentType.GetField(codenameField)?.GetValue(null);
                 return codename != null;
             }
+
             codename = null;
+
             return false;
         }
     }


### PR DESCRIPTION
Tested via the ExtractParameters_WhenGivenTypeWithCodenameAndExistingTypeParameter_DoesNotAddCodenameToParams test method.