### PR TITLE
Updated FakeItEasy to 4.9.1 throughout the entire solution

### DIFF
--- a/KenticoCloud.Delivery.Rx.Tests/KenticoCloud.Delivery.Rx.Tests.csproj
+++ b/KenticoCloud.Delivery.Rx.Tests/KenticoCloud.Delivery.Rx.Tests.csproj
@@ -43,7 +43,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="4.7.1" />
+    <PackageReference Include="FakeItEasy" Version="4.9.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="3.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/KenticoCloud.Delivery.Tests/KenticoCloud.Delivery.Tests.csproj
+++ b/KenticoCloud.Delivery.Tests/KenticoCloud.Delivery.Tests.csproj
@@ -36,7 +36,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="FakeItEasy" Version="4.5.1" />
+    <PackageReference Include="FakeItEasy" Version="4.9.1" />
     <PackageReference Include="NodaTime" Version="2.2.5" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="3.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />


### PR DESCRIPTION
KenticoCloud.Delivery.Tests.DeliveryClientTests.GetStronglyTypedItemsResponse test did not pass with older version of FakeItEasy