### PR TITLE
Added a hint about network outage to the exception message at the end…

### DIFF
--- a/KenticoCloud.Delivery/DeliveryClient.cs
+++ b/KenticoCloud.Delivery/DeliveryClient.cs
@@ -587,7 +587,7 @@ namespace KenticoCloud.Delivery
                 faultContent = await httpResponseMessage.Content.ReadAsStringAsync();
             }
 
-            throw new DeliveryException(httpResponseMessage, faultContent);
+            throw new DeliveryException(httpResponseMessage, "Either the retry policy was disabled or all retry attempts were depleted.\nFault content:\n" + faultContent);
         }
 
         internal IEnumerable<IQueryParameter> ExtractParameters<T>(IEnumerable<IQueryParameter> parameters = null)


### PR DESCRIPTION
The more explicit exception message will be more helpful for understanding possible reasons of network outage. Before printing the fault content, the message now prints out: "Either the retry policy was disabled or all retry attempts were depleted."