### PR TITLE
fixes #146

### DIFF
--- a/KenticoCloud.Delivery.Tests/Builders/DeliveryClient/DeliveryClientBuilderTests.cs
+++ b/KenticoCloud.Delivery.Tests/Builders/DeliveryClient/DeliveryClientBuilderTests.cs
@@ -54,8 +54,7 @@ namespace KenticoCloud.Delivery.Tests.Builders.DeliveryClient
             var mockInlineContentItemsProcessor = A.Fake<IInlineContentItemsProcessor>();
             var mockInlineContentItemsResolver = A.Fake<IInlineContentItemsResolver<object>>();
             var mockCodeFirstTypeProvider = A.Fake<ICodeFirstTypeProvider>();
-            var mockHttp = new MockHttpMessageHandler().ToHttpClient();
-            A.CallTo(() => mockInlineContentItemsProcessor.DefaultResolver).Returns(mockInlineContentItemsResolver);
+            var mockHttp = new MockHttpMessageHandler().ToHttpClient();            
 
             var deliveryClient = (Delivery.DeliveryClient) DeliveryClientBuilder
                 .WithProjectId(ProjectId)
@@ -70,8 +69,7 @@ namespace KenticoCloud.Delivery.Tests.Builders.DeliveryClient
                 .Build();
 
             Assert.Equal(ProjectId, deliveryClient.DeliveryOptions.ProjectId);
-            Assert.Equal(mockContentLinkUrlResolver, deliveryClient.ContentLinkUrlResolver);
-            Assert.Equal(mockInlineContentItemsResolver, deliveryClient.InlineContentItemsProcessor.DefaultResolver);
+            Assert.Equal(mockContentLinkUrlResolver, deliveryClient.ContentLinkUrlResolver);            
             Assert.Equal(mockInlineContentItemsProcessor, deliveryClient.InlineContentItemsProcessor);
             Assert.Equal(mockCodeFirstModelProvider, deliveryClient.CodeFirstModelProvider);
             Assert.Equal(mockCodeFirstPropertyMapper, deliveryClient.CodeFirstPropertyMapper);

--- a/KenticoCloud.Delivery.Tests/CodeFirstModelProviderTests.cs
+++ b/KenticoCloud.Delivery.Tests/CodeFirstModelProviderTests.cs
@@ -1,8 +1,9 @@
-﻿using System;
-using System.Reflection;
-using FakeItEasy;
+﻿using FakeItEasy;
 using KenticoCloud.Delivery.InlineContentItems;
 using Newtonsoft.Json.Linq;
+using System;
+using System.Reflection;
+using KenticoCloud.Delivery.Tests.Factories;
 using Xunit;
 
 namespace KenticoCloud.Delivery.Tests
@@ -20,8 +21,9 @@ namespace KenticoCloud.Delivery.Tests
             A.CallTo(() => propertyMapper.IsMatch(A<PropertyInfo>._, A<string>._, A<string>._)).Returns(true);
             A.CallTo(() => codeFirstTypeProvider.GetType(A<string>._)).Returns(typeof(ContentItemWithSingleRTE));
 
-            var processor = new InlineContentItemsProcessor(null, null);
-            processor.RegisterTypeResolver(new RichTextInlineResolver());
+            var processor = InlineContentItemsProcessorFactory
+                .WithResolver<ContentItemWithSingleRTE,RichTextInlineResolver>()
+                .Build();
             var retriever = new CodeFirstModelProvider(contentLinkUrlResolver, processor, codeFirstTypeProvider, propertyMapper);
 
             var item = JToken.FromObject(rt1);
@@ -44,8 +46,9 @@ namespace KenticoCloud.Delivery.Tests
             A.CallTo(() => codeFirstTypeProvider.GetType(A<string>._)).Returns(typeof(ContentItemWithSingleRTE));
             A.CallTo(() => propertyMapper.IsMatch(A<PropertyInfo>._, A<string>._, A<string>._)).Returns(true);
 
-            var processor = new InlineContentItemsProcessor(null, null);
-            processor.RegisterTypeResolver(new RichTextInlineResolver());
+            var processor = InlineContentItemsProcessorFactory
+                .WithResolver<ContentItemWithSingleRTE,RichTextInlineResolver>()
+                .Build();
             var retriever = new CodeFirstModelProvider(contentLinkUrlResolver, processor, codeFirstTypeProvider, propertyMapper);
 
             var item = JToken.FromObject(rt3);
@@ -184,6 +187,4 @@ namespace KenticoCloud.Delivery.Tests
             elements = new { }
         };
     }
-
-
 }

--- a/KenticoCloud.Delivery.Tests/ContentLinkResolverTests.cs
+++ b/KenticoCloud.Delivery.Tests/ContentLinkResolverTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.IO;
 using KenticoCloud.Delivery.InlineContentItems;
 using KenticoCloud.Delivery.ResiliencePolicy;
+using KenticoCloud.Delivery.Tests.Factories;
 using Microsoft.Extensions.Options;
 using Xunit;
 
@@ -124,7 +125,7 @@ namespace KenticoCloud.Delivery.Tests
             var httpClient = mockHttp.ToHttpClient();
             var resiliencePolicyProvider = new DefaultResiliencePolicyProvider(deliveryOptions);
             var contentLinkUrlResolver = new CustomContentLinkUrlResolver();
-            var contentItemsProcessor = new InlineContentItemsProcessor(new ReplaceWithEmptyStringResolver(), new ReplaceWithEmptyStringForUnretrievedItemsResolver());
+            var contentItemsProcessor = InlineContentItemsProcessorFactory.Create(new ReplaceWithEmptyStringResolver(), new ReplaceWithEmptyStringForUnretrievedItemsResolver());
             var codeFirstModelProvider = new CodeFirstModelProvider(contentLinkUrlResolver, contentItemsProcessor, new CustomTypeProvider(), new CodeFirstPropertyMapper());
             var client = new DeliveryClient(
                 deliveryOptions,

--- a/KenticoCloud.Delivery.Tests/DeliveryClientTests.cs
+++ b/KenticoCloud.Delivery.Tests/DeliveryClientTests.cs
@@ -1,15 +1,15 @@
-﻿using System;
+﻿using FakeItEasy;
+using KenticoCloud.Delivery.Tests.Factories;
+using Polly;
+using RichardSzalay.MockHttp;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
-using FakeItEasy;
-using KenticoCloud.Delivery.Tests.Factories;
 using Xunit;
-using RichardSzalay.MockHttp;
-using Polly;
 
 namespace KenticoCloud.Delivery.Tests
 {
@@ -608,7 +608,7 @@ namespace KenticoCloud.Delivery.Tests
                 .When($"{_baseUrl}/items")
                 .Respond("application/json", File.ReadAllText(Path.Combine(Environment.CurrentDirectory, "Fixtures\\DeliveryClient\\items.json")));
 
-            var client = DeliveryClientFactories.GetMockedDeliveryClientWithProjectId(_guid, _mockHttp);
+            var client = DeliveryClientFactory.GetMockedDeliveryClientWithProjectId(_guid, _mockHttp);
 
             A.CallTo(() => client.ResiliencePolicyProvider.Policy)
                 .Returns(Policy.HandleResult<HttpResponseMessage>(result => true)
@@ -633,7 +633,7 @@ namespace KenticoCloud.Delivery.Tests
                 .When($"{_baseUrl}/items")
                 .Respond("application/json", File.ReadAllText(Path.Combine(Environment.CurrentDirectory, "Fixtures\\DeliveryClient\\items.json")));
 
-            var client = DeliveryClientFactories.GetMockedDeliveryClientWithProjectId(_guid, _mockHttp);
+            var client = DeliveryClientFactory.GetMockedDeliveryClientWithProjectId(_guid, _mockHttp);
 
             var elements = new ElementsParameter(Enumerable.Range(0, 1000000).Select(i => "test").ToArray());
 
@@ -671,7 +671,7 @@ namespace KenticoCloud.Delivery.Tests
                 SecuredProductionApiKey = "someKey"
             };
 
-            var client = DeliveryClientFactories.GetMockedDeliveryClientWithOptions(options, _mockHttp);
+            var client = DeliveryClientFactory.GetMockedDeliveryClientWithOptions(options, _mockHttp);
 
             A.CallTo(() => client.ResiliencePolicyProvider.Policy)
                 .Returns(Policy.HandleResult<HttpResponseMessage>(result => true)
@@ -706,7 +706,7 @@ namespace KenticoCloud.Delivery.Tests
                 .WithHeaders("Authorization", $"Bearer {securityKey}")
                 .Respond("application/json", File.ReadAllText(Path.Combine(Environment.CurrentDirectory, "Fixtures\\DeliveryClient\\items.json")));
 
-            var client = DeliveryClientFactories.GetMockedDeliveryClientWithOptions(options, _mockHttp);
+            var client = DeliveryClientFactory.GetMockedDeliveryClientWithOptions(options, _mockHttp);
 
             A.CallTo(() => client.ResiliencePolicyProvider.Policy)
                 .Returns(Policy.HandleResult<HttpResponseMessage>(result => false)
@@ -728,7 +728,7 @@ namespace KenticoCloud.Delivery.Tests
                 .Respond((request) =>
                     GetResponseAndLogRequest(HttpStatusCode.RequestTimeout, ref actualHttpRequestCount));
 
-            var client = DeliveryClientFactories.GetMockedDeliveryClientWithProjectId(_guid, _mockHttp);
+            var client = DeliveryClientFactory.GetMockedDeliveryClientWithProjectId(_guid, _mockHttp);
 
             A.CallTo(() => client.ResiliencePolicyProvider.Policy)
                 .Returns(Policy.HandleResult<HttpResponseMessage>(result => true).RetryAsync(retryAttempts));
@@ -752,7 +752,7 @@ namespace KenticoCloud.Delivery.Tests
                 ProjectId = _guid.ToString(),
                 EnableResilienceLogic = false
             };
-            var client = DeliveryClientFactories.GetMockedDeliveryClientWithOptions(options, _mockHttp);
+            var client = DeliveryClientFactory.GetMockedDeliveryClientWithOptions(options, _mockHttp);
 
             await Assert.ThrowsAsync<DeliveryException>(async () => await client.GetItemsAsync());
             Assert.Equal(1, actualHttpRequestCount);
@@ -775,7 +775,7 @@ namespace KenticoCloud.Delivery.Tests
                 ProjectId = _guid.ToString(),
                 MaxRetryAttempts = retryAttempts
             };
-            var client = DeliveryClientFactories.GetMockedDeliveryClientWithOptions(options, _mockHttp);
+            var client = DeliveryClientFactory.GetMockedDeliveryClientWithOptions(options, _mockHttp);
 
             A.CallTo(() => client.ResiliencePolicyProvider.Policy)
                 .Returns(Policy.HandleResult<HttpResponseMessage>(result => true).RetryAsync(retryAttempts));
@@ -797,7 +797,7 @@ namespace KenticoCloud.Delivery.Tests
                 .Respond((request) =>
                     GetResponseAndLogRequest(HttpStatusCode.NotImplemented, ref actualHttpRequestCount));
 
-            var client = DeliveryClientFactories.GetMockedDeliveryClientWithProjectId(_guid, _mockHttp);
+            var client = DeliveryClientFactory.GetMockedDeliveryClientWithProjectId(_guid, _mockHttp);
 
             A.CallTo(() => client.ResiliencePolicyProvider.Policy)
                 .Returns(Policy.HandleResult<HttpResponseMessage>(result => true).RetryAsync(retryAttempts));
@@ -825,11 +825,11 @@ namespace KenticoCloud.Delivery.Tests
                 ProjectId = _guid.ToString(),
                 EnableResilienceLogic = false
             };
-            var client = DeliveryClientFactories.GetMockedDeliveryClientWithOptions(options, _mockHttp);
+            var client = DeliveryClientFactory.GetMockedDeliveryClientWithOptions(options, _mockHttp);
 
             A.CallTo(() => client.ResiliencePolicyProvider.Policy)
                 .Returns(Policy.HandleResult<HttpResponseMessage>(result => true).RetryAsync(policyRetryAttempts));
-            
+
             await Assert.ThrowsAsync<DeliveryException>(async () => await client.GetItemsAsync());
             Assert.Equal(expectedAttepts, actualHttpRequestCount);
         }
@@ -851,7 +851,7 @@ namespace KenticoCloud.Delivery.Tests
                 ProjectId = _guid.ToString(),
                 MaxRetryAttempts = ignoredRetryAttempt
             };
-            var client = DeliveryClientFactories.GetMockedDeliveryClientWithOptions(options, _mockHttp);
+            var client = DeliveryClientFactory.GetMockedDeliveryClientWithOptions(options, _mockHttp);
 
             A.CallTo(() => client.ResiliencePolicyProvider.Policy)
                 .Returns(Policy.HandleResult<HttpResponseMessage>(result => true).RetryAsync(policyRetryAttempts));
@@ -875,7 +875,7 @@ namespace KenticoCloud.Delivery.Tests
                 .WithHeaders("X-KC-SDKID", $"nuget.org;{sdkPackageId};{sdkVersion}")
                 .Respond("application/json", File.ReadAllText(Path.Combine(Environment.CurrentDirectory, "Fixtures\\DeliveryClient\\items.json")));
 
-            var client = DeliveryClientFactories.GetMockedDeliveryClientWithProjectId(_guid, _mockHttp);
+            var client = DeliveryClientFactory.GetMockedDeliveryClientWithProjectId(_guid, _mockHttp);
 
             A.CallTo(() => client.ResiliencePolicyProvider.Policy)
                 .Returns(Policy.HandleResult<HttpResponseMessage>(result => false)
@@ -886,6 +886,31 @@ namespace KenticoCloud.Delivery.Tests
             _mockHttp.VerifyNoOutstandingExpectation();
         }
 
+        [Fact]
+        [Trait("Issue", "146")]
+        public async void InitializeMultipleInlineContentItemsResolvers()
+        {
+            string url = $"{_baseUrl}/items/";
+            const string tweetPrefix = "Tweet resolver: ";
+            const string hostedVideoPrefix = "Video resolver: ";
+            _mockHttp
+                .When($"{url}{"coffee_beverages_explained"}")
+                .Respond("application/json", File.ReadAllText(Path.Combine(Environment.CurrentDirectory, "Fixtures\\DeliveryClient\\coffee_beverages_explained.json")));
+
+            var deliveryClient = DeliveryClientBuilder
+                .WithProjectId(_guid)
+                .WithInlineContentItemsResolver(InlineContentItemsResolverFatory.CreateTweetResolver(tweetPrefix))
+                .WithInlineContentItemsResolver(InlineContentItemsResolverFatory.CreateHostedVideoResolver(hostedVideoPrefix))
+                .WithCodeFirstTypeProvider(new CustomTypeProvider())
+                .WithHttpClient(_mockHttp.ToHttpClient())
+                .Build();
+
+            var article = await deliveryClient.GetItemAsync<Article>("coffee_beverages_explained");
+
+            Assert.Contains(tweetPrefix, article.Item.BodyCopy);
+            Assert.Contains(hostedVideoPrefix, article.Item.BodyCopy);
+        }
+
         private DeliveryClient InitializeDeliveryClientWithACustomTypeProvider(MockHttpMessageHandler handler)
         {
             var customTypeProvider = new CustomTypeProvider();
@@ -894,7 +919,7 @@ namespace KenticoCloud.Delivery.Tests
                 null,
                 customTypeProvider,
                 new CodeFirstPropertyMapper());
-            var client = DeliveryClientFactories.GetMockedDeliveryClientWithProjectId(
+            var client = DeliveryClientFactory.GetMockedDeliveryClientWithProjectId(
                 _guid,
                 handler,
                 codeFirstModelProvider,
@@ -911,7 +936,7 @@ namespace KenticoCloud.Delivery.Tests
         {
             var codeFirstPropertyMapper = propertyMapper ?? A.Fake<ICodeFirstPropertyMapper>();
             var codeFirstModelProvider = new CodeFirstModelProvider(null, null, _mockCodeFirstTypeProvider, codeFirstPropertyMapper);
-            var client = DeliveryClientFactories.GetMockedDeliveryClientWithProjectId(_guid, handler, codeFirstModelProvider);
+            var client = DeliveryClientFactory.GetMockedDeliveryClientWithProjectId(_guid, handler, codeFirstModelProvider);
 
             A.CallTo(() => client.ResiliencePolicyProvider.Policy)
                 .Returns(Policy.HandleResult<HttpResponseMessage>(result => true)

--- a/KenticoCloud.Delivery.Tests/DependencyInjectionFrameworks/AutoFacTests.cs
+++ b/KenticoCloud.Delivery.Tests/DependencyInjectionFrameworks/AutoFacTests.cs
@@ -24,11 +24,12 @@ namespace KenticoCloud.Delivery.Tests.DependencyInjectionFrameworks
             var provider = DependencyInjectionFrameworksHelper
                 .GetServiceCollection()
                 .AddScoped<ICodeFirstModelProvider, FakeModelProvider>()
+                .RegisterInlineContentItemResolvers()
                 .BuildAutoFacServiceProvider();
 
             var client = (DeliveryClient)provider.GetService<IDeliveryClient>();
 
-            client.AssertDefaultDependenciesWithCustomCodeFirstModelProvider<FakeModelProvider>();
+            client.AssertDefaultDependenciesWithCodeFirstModelProviderAndInlineContentItemTypeResolvers<FakeModelProvider>();
         }
     }
 }

--- a/KenticoCloud.Delivery.Tests/DependencyInjectionFrameworks/CastleWindsorTests.cs
+++ b/KenticoCloud.Delivery.Tests/DependencyInjectionFrameworks/CastleWindsorTests.cs
@@ -23,12 +23,13 @@ namespace KenticoCloud.Delivery.Tests.DependencyInjectionFrameworks
         {
             var provider = DependencyInjectionFrameworksHelper
                 .GetServiceCollection()
+                .RegisterInlineContentItemResolvers()
                 .AddScoped<ICodeFirstModelProvider, FakeModelProvider>()
                 .BuildWindsorCastleServiceProvider();
 
             var client = (DeliveryClient)provider.GetService<IDeliveryClient>();
 
-            client.AssertDefaultDependenciesWithCustomCodeFirstModelProvider<FakeModelProvider>();
+            client.AssertDefaultDependenciesWithCodeFirstModelProviderAndInlineContentItemTypeResolvers<FakeModelProvider>();
         }
     }
 }

--- a/KenticoCloud.Delivery.Tests/DependencyInjectionFrameworks/Helpers/DependencyInjectionFrameworksHelper.cs
+++ b/KenticoCloud.Delivery.Tests/DependencyInjectionFrameworks/Helpers/DependencyInjectionFrameworksHelper.cs
@@ -3,6 +3,7 @@ using Autofac;
 using Autofac.Extensions.DependencyInjection;
 using Castle.Windsor;
 using Castle.Windsor.MsDependencyInjection;
+using KenticoCloud.Delivery.Tests.Factories;
 using Microsoft.Extensions.DependencyInjection;
 using SimpleInjector;
 using SimpleInjector.Lifestyles;
@@ -16,12 +17,13 @@ namespace KenticoCloud.Delivery.Tests.DependencyInjectionFrameworks.Helpers
         private const string ProjectId = "00a21be4-8fef-4dd9-9380-f4cbb82e260d";
 
         internal static IServiceCollection GetServiceCollection()
-        {
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddDeliveryClient(new DeliveryOptions { ProjectId = ProjectId });
+            => new ServiceCollection()
+                .AddDeliveryClient(new DeliveryOptions {ProjectId = ProjectId});
 
-            return serviceCollection;
-        }
+        internal static IServiceCollection RegisterInlineContentItemResolvers(this IServiceCollection serviceCollection)
+            => serviceCollection
+                .AddDeliveryInlineContentItemsResolver(InlineContentItemsResolverFatory.CreateHostedVideoResolver(null))
+                .AddDeliveryInlineContentItemsResolver<Tweet, FakeTweetResolver>();
 
         internal static IServiceProvider BuildAutoFacServiceProvider(this IServiceCollection serviceCollection)
         {

--- a/KenticoCloud.Delivery.Tests/DependencyInjectionFrameworks/Helpers/FakeTweetResolver.cs
+++ b/KenticoCloud.Delivery.Tests/DependencyInjectionFrameworks/Helpers/FakeTweetResolver.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using KenticoCloud.Delivery.InlineContentItems;
+
+namespace KenticoCloud.Delivery.Tests.DependencyInjectionFrameworks.Helpers
+{
+    internal class FakeTweetResolver : IInlineContentItemsResolver<Tweet>
+    {
+        public string Resolve(ResolvedContentItemData<Tweet> data)
+            => throw new NotImplementedException();
+    }
+}

--- a/KenticoCloud.Delivery.Tests/DependencyInjectionFrameworks/SimpleInjectorTests.cs
+++ b/KenticoCloud.Delivery.Tests/DependencyInjectionFrameworks/SimpleInjectorTests.cs
@@ -24,11 +24,12 @@ namespace KenticoCloud.Delivery.Tests.DependencyInjectionFrameworks
             var container = DependencyInjectionFrameworksHelper
                 .GetServiceCollection()
                 .AddScoped<ICodeFirstModelProvider, FakeModelProvider>()
+                .RegisterInlineContentItemResolvers()
                 .BuildSimpleInjectorServiceProvider();
 
             var client = (DeliveryClient) container.GetInstance<IDeliveryClient>();
 
-            client.AssertDefaultDependenciesWithCustomCodeFirstModelProvider<FakeModelProvider>();
+            client.AssertDefaultDependenciesWithCodeFirstModelProviderAndInlineContentItemTypeResolvers<FakeModelProvider>();
         }
 
         [Fact]

--- a/KenticoCloud.Delivery.Tests/DependencyInjectionFrameworks/UnityTests.cs
+++ b/KenticoCloud.Delivery.Tests/DependencyInjectionFrameworks/UnityTests.cs
@@ -23,12 +23,13 @@ namespace KenticoCloud.Delivery.Tests.DependencyInjectionFrameworks
         {
             var provider = DependencyInjectionFrameworksHelper
                 .GetServiceCollection()
+                .RegisterInlineContentItemResolvers()
                 .AddScoped<ICodeFirstModelProvider, FakeModelProvider>()
                 .BuildUnityServiceProvider();
 
             var client = (DeliveryClient)provider.GetService<IDeliveryClient>();
 
-            client.AssertDefaultDependenciesWithCustomCodeFirstModelProvider<FakeModelProvider>();
+            client.AssertDefaultDependenciesWithCodeFirstModelProviderAndInlineContentItemTypeResolvers<FakeModelProvider>();
         }
     }
 }

--- a/KenticoCloud.Delivery.Tests/Factories/DeliveryClientFactory.cs
+++ b/KenticoCloud.Delivery.Tests/Factories/DeliveryClientFactory.cs
@@ -7,7 +7,7 @@ using RichardSzalay.MockHttp;
 
 namespace KenticoCloud.Delivery.Tests.Factories
 {
-    internal static class DeliveryClientFactories
+    internal static class DeliveryClientFactory
     {
         private static readonly MockHttpMessageHandler MockHttp = new MockHttpMessageHandler();
         private static ICodeFirstModelProvider _mockCodeFirstModelProvider = A.Fake<ICodeFirstModelProvider>();

--- a/KenticoCloud.Delivery.Tests/Factories/InlineContentItemsProcessorFactory.cs
+++ b/KenticoCloud.Delivery.Tests/Factories/InlineContentItemsProcessorFactory.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using KenticoCloud.Delivery.InlineContentItems;
+
+namespace KenticoCloud.Delivery.Tests.Factories
+{
+    internal class InlineContentItemsProcessorFactory
+    {
+        private readonly IList<ITypelessInlineContentItemsResolver> _resolvers = new List<ITypelessInlineContentItemsResolver>();
+
+        public static InlineContentItemsProcessor Create(
+            IInlineContentItemsResolver<object> defaultResolver = null,
+            IInlineContentItemsResolver<UnretrievedContentItem> unretrievedInlineContentItemsResolver = null)
+            => new InlineContentItemsProcessor(
+                defaultResolver,
+                unretrievedInlineContentItemsResolver,
+                Enumerable.Empty<ITypelessInlineContentItemsResolver>());
+
+        public static InlineContentItemsProcessorFactory WithResolver<TContentItem>(IInlineContentItemsResolver<TContentItem> resolver)
+            => new InlineContentItemsProcessorFactory().AndResolver(resolver);
+
+        public static InlineContentItemsProcessorFactory WithResolver<TContentItem, TResolver>()
+            where TResolver : IInlineContentItemsResolver<TContentItem>, new()
+            => new InlineContentItemsProcessorFactory().AndResolver<TContentItem, TResolver>();
+
+        private InlineContentItemsProcessorFactory()
+        { }
+
+        public InlineContentItemsProcessorFactory AndResolver<TContentItem>(IInlineContentItemsResolver<TContentItem> resolver)
+        {
+            var typelessResolver = TypelessInlineContentItemsResolver.Create(resolver);
+            _resolvers.Add(typelessResolver);
+
+            return this;
+        }
+
+        public InlineContentItemsProcessorFactory AndResolver<TContentItem, TResolver>()
+            where TResolver : IInlineContentItemsResolver<TContentItem>, new()
+            => AndResolver(new TResolver());
+
+        public InlineContentItemsProcessor Build(IInlineContentItemsResolver<object> defaultResolver = null, IInlineContentItemsResolver<UnretrievedContentItem> unretrievedInlineContentItemsResolver = null)
+            => new InlineContentItemsProcessor(defaultResolver, unretrievedInlineContentItemsResolver, _resolvers);
+    }
+}

--- a/KenticoCloud.Delivery.Tests/Factories/InlineContentItemsResolverFatory.cs
+++ b/KenticoCloud.Delivery.Tests/Factories/InlineContentItemsResolverFatory.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Linq;
+using KenticoCloud.Delivery.InlineContentItems;
+
+namespace KenticoCloud.Delivery.Tests.Factories
+{
+    internal static class InlineContentItemsResolverFatory
+    {
+        public static IInlineContentItemsResolver<HostedVideo> CreateHostedVideoResolver(string messagePrefix)
+            => new Resolver<HostedVideo>(messagePrefix, video => video.VideoHost.First().Name);
+
+        public static IInlineContentItemsResolver<Tweet> CreateTweetResolver(string messagePrefix)
+            => new Resolver<Tweet>(messagePrefix, tweet => tweet.TweetLink);
+
+        private class Resolver<TContentItem> : IInlineContentItemsResolver<TContentItem>
+        {
+            private readonly string _messagePrefix;
+            private readonly Func<TContentItem, string> _messageSelector;
+
+            public Resolver(string messagePrefix, Func<TContentItem, string> messageSelector)
+            {
+                this._messagePrefix = messagePrefix;
+                this._messageSelector = messageSelector;
+            }
+
+            public string Resolve(ResolvedContentItemData<TContentItem> data)
+            {
+                return _messagePrefix + _messageSelector(data.Item);
+            }
+        }
+    }
+}

--- a/KenticoCloud.Delivery/Builders/DeliveryClient/DeliveryClientBuilderImplementation.cs
+++ b/KenticoCloud.Delivery/Builders/DeliveryClient/DeliveryClientBuilderImplementation.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Net.Http;
-using KenticoCloud.Delivery.Builders.DeliveryOptions;
+﻿using KenticoCloud.Delivery.Builders.DeliveryOptions;
 using KenticoCloud.Delivery.InlineContentItems;
 using KenticoCloud.Delivery.ResiliencePolicy;
 using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Net.Http;
 
 namespace KenticoCloud.Delivery.Builders.DeliveryClient
 {
@@ -42,7 +42,7 @@ namespace KenticoCloud.Delivery.Builders.DeliveryClient
             => RegisterOrThrow(contentLinkUrlResolver, nameof(contentLinkUrlResolver));
 
         IOptionalClientSetup IOptionalClientSetup.WithInlineContentItemsResolver<T>(IInlineContentItemsResolver<T> inlineContentItemsResolver)
-            => RegisterOrThrow(inlineContentItemsResolver, nameof(inlineContentItemsResolver));
+            => RegisterInlineContentItemsResolverOrThrow(inlineContentItemsResolver);
 
         IOptionalClientSetup IOptionalClientSetup.WithInlineContentItemsProcessor(IInlineContentItemsProcessor inlineContentItemsProcessor)
             => RegisterOrThrow(inlineContentItemsProcessor, nameof(inlineContentItemsProcessor));
@@ -79,6 +79,18 @@ namespace KenticoCloud.Delivery.Builders.DeliveryClient
             }
 
             _serviceCollection.AddSingleton(instance);
+
+            return this;
+        }
+
+        private DeliveryClientBuilderImplementation RegisterInlineContentItemsResolverOrThrow<TContentItem>(IInlineContentItemsResolver<TContentItem> inlineContentItemsResolver)
+        {
+            if (inlineContentItemsResolver == null)
+            {
+                throw new ArgumentNullException(nameof(inlineContentItemsResolver));
+            }
+
+            _serviceCollection.AddDeliveryInlineContentItemsResolver(inlineContentItemsResolver);
 
             return this;
         }

--- a/KenticoCloud.Delivery/InlineContentItems/IInlineContentItemsProcessor.cs
+++ b/KenticoCloud.Delivery/InlineContentItems/IInlineContentItemsProcessor.cs
@@ -6,11 +6,7 @@ namespace KenticoCloud.Delivery.InlineContentItems
     /// Interface implemented for processing inline content items in HTML
     /// </summary>
     public interface IInlineContentItemsProcessor
-{        /// <summary>
-        /// Gets or sets resolver used in case no other resolver was registered for type of inline content item
-        /// </summary>
-        IInlineContentItemsResolver<object> DefaultResolver { get; set; }
-
+    {
         /// <summary>
         /// Processes HTML input and returns it with inline content items replaced with resolvers output.
         /// </summary>
@@ -18,14 +14,7 @@ namespace KenticoCloud.Delivery.InlineContentItems
         /// <param name="usedContentItems">Content items referenced as inline content items</param>
         /// <returns>HTML with inline content items replaced with resolvers output</returns>
         string Process(string value, Dictionary<string, object> usedContentItems);
-
-        /// <summary>
-        /// Function used for registering content type specific resolvers used during processing.
-        /// </summary>
-        /// <param name="resolver">Method which is used for specific content type as resolver.</param>
-        /// <typeparam name="T">Content type which is resolver resolving.</typeparam>
-        void RegisterTypeResolver<T>(IInlineContentItemsResolver<T> resolver);
-
+        
         /// <summary>
         /// Removes all content items from given HTML content.
         /// </summary>

--- a/KenticoCloud.Delivery/InlineContentItems/IInlineContentItemsResolver.cs
+++ b/KenticoCloud.Delivery/InlineContentItems/IInlineContentItemsResolver.cs
@@ -1,18 +1,11 @@
 ﻿namespace KenticoCloud.Delivery.InlineContentItems
 {
     /// <summary>
-    /// Interface which is only used to be extended by it's generic version
-    /// </summary>
-    public interface IInlineContentItemsResolver
-    {
-        
-    }
-
-    /// <summary>
     /// An interface, implemented to be registered as resolver for specific content type of inline content item
     /// </summary>
     /// <typeparam name="T">Content type to be resolved</typeparam>
-    public interface IInlineContentItemsResolver<T> : IInlineContentItemsResolver
+    /// <seealso cref="ITypelessInlineContentItemsResolver"/>
+    public interface IInlineContentItemsResolver<T>
     {
         /// <summary>
         /// Method implementing the resolving of inline content item. Result should be valid HTML code

--- a/KenticoCloud.Delivery/InlineContentItems/ITypelessInlineContentItemsResolver.cs
+++ b/KenticoCloud.Delivery/InlineContentItems/ITypelessInlineContentItemsResolver.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using KenticoCloud.Delivery.Builders.DeliveryClient;
+
+namespace KenticoCloud.Delivery.InlineContentItems
+{
+    /// <summary>
+    /// An interface, implemented to be registered in an collection passed to <see cref="InlineContentItemsProcessor"/>.
+    /// Such collection provide the processor with generic resolvers for otherwise specific content type of inline content item.
+    /// </summary>
+    /// <seealso cref="IInlineContentItemsResolver{T}"/>
+    /// <remarks>
+    /// The <see cref="ServiceCollectionExtensions.AddDeliveryInlineContentItemsResolver{TContentItem}"/> or <see cref="IOptionalClientSetup.WithInlineContentItemsResolver{T}"/>
+    /// (in <see cref="DeliveryClientBuilder"/>) should always be used to create new instances of this interface. All such instances will be registered in an dependency
+    /// container and later used for <see cref="InlineContentItemsProcessor"/> instantiation.
+    /// </remarks>
+    internal interface ITypelessInlineContentItemsResolver
+    {
+        /// <summary>
+        /// Type of an inline content item.
+        /// </summary>
+        Type ContentItemType { get; }
+
+        /// <summary>
+        /// Transformation function resolving an inline content item of a given inline content item.
+        /// </summary>
+        /// <param name="item">An inline content item of given <see cref="ContentItemType"/></param>
+        /// <returns>String representation of the <paramref name="item"/></returns>
+        string ResolveItem(object item);
+    }
+}

--- a/KenticoCloud.Delivery/InlineContentItems/InlineContentItemsProcessor.cs
+++ b/KenticoCloud.Delivery/InlineContentItems/InlineContentItemsProcessor.cs
@@ -7,13 +7,6 @@ using System.Linq;
 namespace KenticoCloud.Delivery.InlineContentItems
 {
     /// <summary>
-    /// Resolves strongly typed model into string.
-    /// </summary>
-    /// <param name="o">Strongly typed model.</param>
-    /// <returns>String representation of the model (can be HTML, for instance).</returns>
-    internal delegate string ResolveInlineContent(object o);
-
-    /// <summary>
     /// Processor responsible for parsing HTML input and resolving inline content items referenced in them using registered resolvers
     /// </summary>
     internal class InlineContentItemsProcessor : IInlineContentItemsProcessor

--- a/KenticoCloud.Delivery/InlineContentItems/TypelessInlineContentItemsResolver.cs
+++ b/KenticoCloud.Delivery/InlineContentItems/TypelessInlineContentItemsResolver.cs
@@ -1,0 +1,43 @@
+﻿using System;
+
+namespace KenticoCloud.Delivery.InlineContentItems
+{
+    /// <summary>
+    /// Strips an <see cref="IInlineContentItemsResolver{T}"/> of its generic type, so it can be used generically by <see cref="InlineContentItemsProcessor"/>.
+    /// </summary>
+    internal class TypelessInlineContentItemsResolver : ITypelessInlineContentItemsResolver
+    {
+        /// <summary>
+        /// Creates new instance of <see cref="TypelessInlineContentItemsResolver"/> for given <paramref name="resolver"/>.
+        /// </summary>
+        /// <typeparam name="TContentItem">Content item type the <paramref name="resolver"/> works with</typeparam>
+        /// <param name="resolver">Resolver for specific content type of inline content item</param>
+        public static ITypelessInlineContentItemsResolver Create<TContentItem>(IInlineContentItemsResolver<TContentItem> resolver)
+        {
+            if (resolver == null)
+            {
+                throw new ArgumentNullException(nameof(resolver));
+            }
+
+            string Resolve(object item) => resolver.Resolve(new ResolvedContentItemData<TContentItem> { Item = (TContentItem)item });
+
+            return new TypelessInlineContentItemsResolver(Resolve, typeof(TContentItem));
+        }
+
+        private readonly Func<object, string> _resolveItem;
+
+        /// <inheritdoc cref="ITypelessInlineContentItemsResolver.ContentItemType"/>
+        public Type ContentItemType { get; }
+
+
+        /// <inheritdoc cref="ITypelessInlineContentItemsResolver.ResolveItem"/>
+        public string ResolveItem(object item)
+            => _resolveItem(item);
+
+        private TypelessInlineContentItemsResolver(Func<object, string> resolveItem, Type contentItemType)
+        {
+            _resolveItem = resolveItem;
+            ContentItemType = contentItemType;
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

Which issue does this fix? Fixes #146 

* Non-generic `IInlineContentItemsResolver` was removed as it was an unusable interface (breaking change) that might eventually cause confusion in combination with `ITypelessInlineContentItemsResolver`. 
* An independent `ITypelessInlineContentItemsResolver` interface was introduced to wrap and hide `IInlineContentItemsResolver<TContentItem>` resolvers and provide them in a non-generic way to the `InlineContentItemsProcessor` that later puts inline content items through the resolver in order to obtain their string representation – I've chosen this way to mitigate a breaking change in `IInlineContentItemsResolver<>` (aka all existing resolvers).
* New extension methods for IServiceCollection were introduced to allow registration of custom inline content items resolvers (docs needs to be eventually updated).
* I have added some tests for the `IInlineContentItemsResolver<>`s to the DI framework integration tests so we can be sure that the approach would work.

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [ ] Docu has been updated (if applicable)
- [x] Temporary settings (e.g. project ID used during development and testing) have been reverted to defaults

### How to test

Follow the repro steps in #146

Note: there's another breaking change - Petr removed some methods from one interface. The methods didn't really make sense there (see https://github.com/Kentico/delivery-sdk-net/pull/147).