### PR TITLE
Inline content resolver in v9 has unnecessary wrapping (KA-520)

### DIFF
--- a/KenticoCloud.Delivery.Tests/CodeFirstModelProviderTests.cs
+++ b/KenticoCloud.Delivery.Tests/CodeFirstModelProviderTests.cs
@@ -20,20 +20,20 @@ namespace KenticoCloud.Delivery.Tests
             var contentLinkUrlResolver = A.Fake<IContentLinkUrlResolver>();
             var propertyMapper = A.Fake<ICodeFirstPropertyMapper>();
             A.CallTo(() => propertyMapper.IsMatch(A<PropertyInfo>._, A<string>._, A<string>._)).Returns(true);
-            A.CallTo(() => codeFirstTypeProvider.GetType(A<string>._)).Returns(typeof(ContentItemWithSingleRTE));
+            A.CallTo(() => codeFirstTypeProvider.GetType(A<string>._)).Returns(typeof(ContentItemWithSingleRte));
 
             var processor = InlineContentItemsProcessorFactory
-                .WithResolver<ContentItemWithSingleRTE,RichTextInlineResolver>()
+                .WithResolver(ResolveItemWithSingleRte)
                 .Build();
             var retriever = new CodeFirstModelProvider(contentLinkUrlResolver, processor, codeFirstTypeProvider, propertyMapper);
 
-            var item = JToken.FromObject(rt1);
-            var linkedItems = JToken.FromObject(linkedItemsForItemWithTwoReferencedContentItems);
+            var item = JToken.FromObject(Rt1);
+            var linkedItems = JToken.FromObject(LinkedItemsForItemWithTwoReferencedContentItems);
 
-            var result = retriever.GetContentItemModel<ContentItemWithSingleRTE>(item, linkedItems);
+            var result = retriever.GetContentItemModel<ContentItemWithSingleRte>(item, linkedItems);
 
-            Assert.Equal("<span>FirstRT</span><span>SecondRT</span><span>FirstRT</span>", result.RT);
-            Assert.IsType<ContentItemWithSingleRTE>(result);
+            Assert.Equal("<span>FirstRT</span><span>SecondRT</span><span>FirstRT</span>", result.Rt);
+            Assert.IsType<ContentItemWithSingleRte>(result);
         }
 
         [Fact]
@@ -46,19 +46,19 @@ namespace KenticoCloud.Delivery.Tests
             A.CallTo(() => propertyMapper.IsMatch(A<PropertyInfo>._, A<string>._, A<string>._)).Returns(true);
 
             var processor = InlineContentItemsProcessorFactory
-                .WithResolver<UnknownContentItem, ReplaceWithWarningAboutUnknownItemResolver>()
+                .WithResolver(factory => factory.ResolveTo<UnknownContentItem>(unknownItem => $"Content type '{unknownItem.Type}' has no corresponding model."))
                 .Build();
             var retriever = new CodeFirstModelProvider(contentLinkUrlResolver, processor, codeFirstTypeProvider, propertyMapper);
 
-            var item = JToken.FromObject(rt5);
-            var linkedItems = JToken.FromObject(linkedItemWithNoModel);
+            var item = JToken.FromObject(Rt5);
+            var linkedItems = JToken.FromObject(LinkedItemWithNoModel);
             var expectedResult =
                 $"<span>RT</span>Content type '{linkedItems.SelectToken("linkedItemWithNoModel.system.type")}' has no corresponding model.";
 
-            var result = retriever.GetContentItemModel<ContentItemWithSingleRTE>(item, linkedItems);
+            var result = retriever.GetContentItemModel<ContentItemWithSingleRte>(item, linkedItems);
             
-            Assert.Equal(expectedResult, result.RT);
-            Assert.IsType<ContentItemWithSingleRTE>(result);
+            Assert.Equal(expectedResult, result.Rt);
+            Assert.IsType<ContentItemWithSingleRte>(result);
         }
 
         [Fact]
@@ -69,29 +69,29 @@ namespace KenticoCloud.Delivery.Tests
             var codeFirstTypeProvider = A.Fake<ICodeFirstTypeProvider>();
             var contentLinkUrlResolver = A.Fake<IContentLinkUrlResolver>();
             var propertyMapper = A.Fake<ICodeFirstPropertyMapper>();
-            A.CallTo(() => codeFirstTypeProvider.GetType(A<string>._)).Returns(typeof(ContentItemWithSingleRTE));
+            A.CallTo(() => codeFirstTypeProvider.GetType(A<string>._)).Returns(typeof(ContentItemWithSingleRte));
             A.CallTo(() => propertyMapper.IsMatch(A<PropertyInfo>._, A<string>._, A<string>._)).Returns(true);
 
             var processor = InlineContentItemsProcessorFactory
-                .WithResolver<ContentItemWithSingleRTE,RichTextInlineResolver>()
+                .WithResolver(ResolveItemWithSingleRte)
                 .Build();
             var retriever = new CodeFirstModelProvider(contentLinkUrlResolver, processor, codeFirstTypeProvider, propertyMapper);
 
-            var item = JToken.FromObject(rt3);
-            var linkedItems = JToken.FromObject(linkedItemsForItemReferencingItself);
+            var item = JToken.FromObject(Rt3);
+            var linkedItems = JToken.FromObject(LinkedItemsForItemReferencingItself);
 
-            var result = retriever.GetContentItemModel<ContentItemWithSingleRTE>(item, linkedItems);
+            var result = retriever.GetContentItemModel<ContentItemWithSingleRte>(item, linkedItems);
 
-            Assert.Equal("<span>RT</span><span>RT</span>", result.RT);
-            Assert.IsType<ContentItemWithSingleRTE>(result);
+            Assert.Equal("<span>RT</span><span>RT</span>", result.Rt);
+            Assert.IsType<ContentItemWithSingleRte>(result);
         }
 
+        /// <seealso href="https://github.com/Kentico/delivery-sdk-net/issues/126"/>
         [Fact]
-        /// <see href="https://github.com/Kentico/delivery-sdk-net/issues/126"/>
         public void GetContentItemModelRetrievingContentModelWithUnknownTypeReturnNull()
         {
-            var item = JToken.FromObject(rt4);
-            var linkedItems = JToken.FromObject(linkedItemsForItemWithTwoReferencedContentItems);
+            var item = JToken.FromObject(Rt4);
+            var linkedItems = JToken.FromObject(LinkedItemsForItemWithTwoReferencedContentItems);
 
             var contentLinkUrlResolver = A.Fake<IContentLinkUrlResolver>();
             var inlineContentItemsProcessor = A.Fake<IInlineContentItemsProcessor>();
@@ -103,26 +103,7 @@ namespace KenticoCloud.Delivery.Tests
             Assert.Null(modelProvider.GetContentItemModel<object>(item, linkedItems));
         }
 
-        private class ReplaceWithWarningAboutUnknownItemResolver : IInlineContentItemsResolver<UnknownContentItem>
-        {
-            public string Resolve(ResolvedContentItemData<UnknownContentItem> item)
-                => $"Content type '{item.Item.Type}' has no corresponding model.";
-        }
-
-        private class ContentItemWithSingleRTE
-        {
-            public string RT { get; set; }
-        }
-
-        private class RichTextInlineResolver : IInlineContentItemsResolver<ContentItemWithSingleRTE>
-        {
-            public string Resolve(ResolvedContentItemData<ContentItemWithSingleRTE> data)
-            {
-                return data.Item.RT;
-            }
-        }
-
-        private static readonly object rt1 = new
+        private static readonly object Rt1 = new
         {
             system = new
             {
@@ -146,7 +127,7 @@ namespace KenticoCloud.Delivery.Tests
             }
         };
 
-        private static readonly object rt2 = new
+        private static readonly object Rt2 = new
         {
             system = new
             {
@@ -170,13 +151,7 @@ namespace KenticoCloud.Delivery.Tests
             }
         };
 
-        private static readonly object linkedItemsForItemWithTwoReferencedContentItems = new
-        {
-            rt2,
-            rt1
-        };
-
-        private static readonly object rt3 = new
+        private static readonly object Rt3 = new
         {
             system = new
             {
@@ -200,31 +175,7 @@ namespace KenticoCloud.Delivery.Tests
             }
         };
 
-        private static readonly object linkedItemsForItemReferencingItself = new
-        {
-            rt3
-        };
-
-        private static readonly object linkedItemWithNoModel = new
-        {
-            linkedItemWithNoModel = new
-            {
-                system = new
-                {
-                    id = "473cd60b-a2a7-4e5b-8353-5d1995dd4b50",
-                    name = "linkedItemWithNoModel",
-                    codename = "linkedItemWithNoModel",
-                    language = "en-US",
-                    type = "newType",
-                    sitemap_locations = new string[0],
-                    last_modified = new DateTime(2017, 06, 01, 11, 43, 33)
-                },
-                elements = new
-                    { }
-            }
-        };
-
-        private static readonly object rt4 = new
+        private static readonly object Rt4 = new
         {
             system = new
             {
@@ -238,7 +189,7 @@ namespace KenticoCloud.Delivery.Tests
             elements = new { }
         };
 
-        private static readonly object rt5 = new
+        private static readonly object Rt5 = new
         {
             system = new
             {
@@ -260,5 +211,43 @@ namespace KenticoCloud.Delivery.Tests
                 }
             }
         };
+
+        private static readonly object LinkedItemWithNoModel = new
+        {
+            linkedItemWithNoModel = new
+            {
+                system = new
+                {
+                    id = "473cd60b-a2a7-4e5b-8353-5d1995dd4b50",
+                    name = "linkedItemWithNoModel",
+                    codename = "linkedItemWithNoModel",
+                    language = "en-US",
+                    type = "newType",
+                    sitemap_locations = new string[0],
+                    last_modified = new DateTime(2017, 06, 01, 11, 43, 33)
+                },
+                elements = new
+                    { }
+            }
+        };
+
+        private static readonly object LinkedItemsForItemWithTwoReferencedContentItems = new
+        {
+            rt2 = Rt2,
+            rt1 = Rt1
+        };
+
+        private static readonly object LinkedItemsForItemReferencingItself = new
+        {
+            rt3 = Rt3
+        };
+
+        private static IInlineContentItemsResolver<ContentItemWithSingleRte> ResolveItemWithSingleRte(InlineContentItemsResolverFactory factory)
+            => factory.ResolveTo<ContentItemWithSingleRte>(item => item.Rt);
+
+        private class ContentItemWithSingleRte
+        {
+            public string Rt { get; set; }
+        }
     }
 }

--- a/KenticoCloud.Delivery.Tests/ContentItemsInRichTextProcessorTests.cs
+++ b/KenticoCloud.Delivery.Tests/ContentItemsInRichTextProcessorTests.cs
@@ -13,7 +13,7 @@ namespace KenticoCloud.Delivery.Tests
         [Fact]
         public void ProcessedHtmlIsSameIfNoContentItemsAreIncluded()
         {
-            var inputHtml = $"<p>Lorem ipsum etc..<a>asdf</a>..</p>";
+            var inputHtml = "<p>Lorem ipsum etc..<a>asdf</a>..</p>";
             var inlineContentItemsProcessor = InlineContentItemsProcessorFactory.Create();
             var processedContentItems = new Dictionary<string, object>();
 
@@ -32,9 +32,9 @@ namespace KenticoCloud.Delivery.Tests
             var plainHtml = $"<p>Lorem ipsum etc..<a>asdf</a>..</p>";
             var input = insertedObject1 + plainHtml + insertedObject2;
             var inlineContentItemsProcessor = InlineContentItemsProcessorFactory
-                .WithResolver<DummyProcessedContentItem, DummyResolver>()
+                .WithResolver(factory => factory.ResolveToMessage<DummyItem>(string.Empty))
                 .Build();
-            var processedContentItems = new Dictionary<string, object> {{insertedContentName1, new DummyProcessedContentItem()}, {insertedContentName2, new DummyProcessedContentItem()} };
+            var processedContentItems = new Dictionary<string, object> {{insertedContentName1, new DummyItem()}, {insertedContentName2, new DummyItem()} };
 
             var result = inlineContentItemsProcessor.Process(input, processedContentItems);
 
@@ -45,22 +45,22 @@ namespace KenticoCloud.Delivery.Tests
         public void NestedInlineContentItemIsProcessedByDummyProcessor()
         {
             var insertedContentName = "dummyCodename1";
+            var callsForResolve = 0;
             string wrapperWithObject = WrapElementWithDivs(GetContentItemObjectElement(insertedContentName));
             var plainHtml = $"<p>Lorem ipsum etc..<a>asdf</a>..</p>";
             var input = plainHtml + wrapperWithObject;
             var processedContentItems = new Dictionary<string, object>
             {
-                {insertedContentName, new DummyProcessedContentItem()}
+                {insertedContentName, new DummyItem()},
             };
-            var contentItemResolver = new DummyResolver();
             var inlineContentItemsProcessor = InlineContentItemsProcessorFactory
-                .WithResolver(contentItemResolver)
+                .WithResolver(factory => factory.ResolveTo<DummyItem>(_ => { callsForResolve++; return string.Empty; }))
                 .Build();
 
             var result = inlineContentItemsProcessor.Process(input, processedContentItems);
 
             Assert.Equal(plainHtml + WrapElementWithDivs(string.Empty), result);
-            Assert.Equal(1, contentItemResolver.callsForResolve);
+            Assert.Equal(1, callsForResolve);
 
         }
 
@@ -74,10 +74,10 @@ namespace KenticoCloud.Delivery.Tests
             var input = plainHtml + wrapperWithObject;
             var processedContentItems = new Dictionary<string, object>
             {
-                {insertedContentName, new DummyProcessedContentItem {Value = insertedContentItemValue} }
+                {insertedContentName, new DummyItem {Value = insertedContentItemValue} }
             };
             var inlineContentItemsProcessor = InlineContentItemsProcessorFactory
-                .WithResolver<DummyProcessedContentItem, ResolverReturningValue>()
+                .WithResolver(factory => factory.ResolveTo<DummyItem>(item => item.Value ?? string.Empty))
                 .Build();
 
 
@@ -97,10 +97,10 @@ namespace KenticoCloud.Delivery.Tests
             const string insertedContentItemValue = "dummyValue";
             var processedContentItems = new Dictionary<string, object>
             {
-                {insertedContentName, new DummyProcessedContentItem {Value = insertedContentItemValue}}
+                {insertedContentName, new DummyItem {Value = insertedContentItemValue}}
             };
             var inlineContentItemsProcessor = InlineContentItemsProcessorFactory
-                .WithResolver<DummyProcessedContentItem, ResolverReturningElement>()
+                .WithResolver(ResolveDummyItemToSpan)
                 .Build();
 
             var result = inlineContentItemsProcessor.Process(input, processedContentItems);
@@ -158,15 +158,15 @@ namespace KenticoCloud.Delivery.Tests
 
             var processedContentItems = new Dictionary<string, object>
             {
-                {insertedImage1CodeName, new DummyImageContentItem {Source = insertedImage1Source}},
-                {insertedImage2CodeName, new DummyImageContentItem {Source = insertedImage2Source}},
-                {insertedDummyItem1CodeName, new DummyProcessedContentItem {Value = insertedDummyItem1Value}},
-                {insertedDummyItem2CodeName, new DummyProcessedContentItem {Value = insertedDummyItem2Value}},
-                {insertedDummyItem3CodeName, new DummyProcessedContentItem {Value = insertedDummyItem3Value}},
+                {insertedImage1CodeName, new DummyImageItem {Source = insertedImage1Source}},
+                {insertedImage2CodeName, new DummyImageItem {Source = insertedImage2Source}},
+                {insertedDummyItem1CodeName, new DummyItem {Value = insertedDummyItem1Value}},
+                {insertedDummyItem2CodeName, new DummyItem {Value = insertedDummyItem2Value}},
+                {insertedDummyItem3CodeName, new DummyItem {Value = insertedDummyItem3Value}},
             };
             var inlineContentItemsProcessor = InlineContentItemsProcessorFactory
-                .WithResolver<DummyProcessedContentItem, ResolverReturningElement>()
-                .AndResolver<DummyImageContentItem, DummyImageResolver>()
+                .WithResolver(ResolveDummyItemToSpan)
+                .AndResolver(ResolveDummyImageToImg)
                 .Build();
 
             var result = inlineContentItemsProcessor.Process(htmlInput, processedContentItems);
@@ -224,17 +224,16 @@ namespace KenticoCloud.Delivery.Tests
 
             var processedContentItems = new Dictionary<string, object>
             {
-                {insertedImage1CodeName, new DummyImageContentItem() {Source = insertedImage1Source}},
+                {insertedImage1CodeName, new DummyImageItem {Source = insertedImage1Source}},
                 {insertedImage2CodeName, new UnretrievedContentItem()},
-                {insertedDummyItem1CodeName, new DummyProcessedContentItem() {Value = insertedDummyItem1Value}},
+                {insertedDummyItem1CodeName, new DummyItem {Value = insertedDummyItem1Value}},
                 {insertedDummyItem2CodeName, new UnretrievedContentItem()},
-                {insertedDummyItem3CodeName, new DummyProcessedContentItem() {Value = insertedDummyItem3Value}},
+                {insertedDummyItem3CodeName, new DummyItem {Value = insertedDummyItem3Value}},
             };
-            var unretrievedInlineContentItemsResolver = new UnretrievedItemsMessageReturningResolver(unretrievedItemMessage);
             var inlineContentItemsProcessor = InlineContentItemsProcessorFactory
-                .WithResolver<DummyProcessedContentItem, ResolverReturningElement>()
-                .AndResolver<DummyImageContentItem, DummyImageResolver>()
-                .AndResolver(unretrievedInlineContentItemsResolver)
+                .WithResolver(ResolveDummyItemToSpan)
+                .AndResolver(ResolveDummyImageToImg)
+                .AndResolver(factory => factory.ResolveToMessage<UnretrievedContentItem>(unretrievedItemMessage))
                 .Build();
 
             var result = inlineContentItemsProcessor.Process(htmlInput, processedContentItems);
@@ -292,18 +291,16 @@ namespace KenticoCloud.Delivery.Tests
 
             var processedContentItems = new Dictionary<string, object>
             {
-                {insertedImage1CodeName, new DummyImageContentItem() {Source = insertedImage1Source}},
+                {insertedImage1CodeName, new DummyImageItem {Source = insertedImage1Source}},
                 {insertedImage2CodeName, new UnretrievedContentItem()},
-                {insertedDummyItem1CodeName, new DummyProcessedContentItem() {Value = insertedDummyItem1Value}},
+                {insertedDummyItem1CodeName, new DummyItem {Value = insertedDummyItem1Value}},
                 {insertedDummyItem2CodeName, new UnretrievedContentItem()},
-                {insertedDummyItem3CodeName, new DummyProcessedContentItem() {Value = insertedDummyItem3Value}},
+                {insertedDummyItem3CodeName, new DummyItem {Value = insertedDummyItem3Value}},
             };
-            var unretrievedInlineContentItemsResolver = new UnretrievedItemsMessageReturningResolver(unretrievedItemMessage);
-            var defaultResolver = new MessageReturningResolver(defaultResolverMessage);
             var inlineContentItemsProcessor = InlineContentItemsProcessorFactory
-                .WithResolver<DummyProcessedContentItem, ResolverReturningElement>()
-                .AndResolver(defaultResolver)
-                .AndResolver(unretrievedInlineContentItemsResolver)
+                .WithResolver(ResolveDummyItemToSpan)
+                .AndResolver(factory => factory.ResolveByDefaultToMessage(defaultResolverMessage))
+                .AndResolver(factory => factory.ResolveToMessage<UnretrievedContentItem>(unretrievedItemMessage))
                 .Build();
 
 
@@ -317,7 +314,6 @@ namespace KenticoCloud.Delivery.Tests
         public void UnretrievedContentItemIsResolvedByUnretrievedProcessor()
         {
             const string insertedContentName = "dummyCodename1";
-            const string message = "Unretrieved item detected";
             var insertedObject = GetContentItemObjectElement(insertedContentName);
             var wrapperWithObject = WrapElementWithDivs(insertedObject);
             var plainHtml = "<p>Lorem ipsum etc..<a>asdf</a>..</p>";
@@ -326,19 +322,19 @@ namespace KenticoCloud.Delivery.Tests
             {
                 {insertedContentName, new UnretrievedContentItem()}
             };
-            var unresolvedContentItemResolver = new UnretrievedItemsMessageReturningResolver(message);
-            var inlineContentItemsProcessor = InlineContentItemsProcessorFactory.WithResolver(unresolvedContentItemResolver).Build();
+            var inlineContentItemsProcessor = InlineContentItemsProcessorFactory
+                .WithResolver(factory => factory.ResolveToType<UnretrievedContentItem>())
+                .Build();
 
             var result = inlineContentItemsProcessor.Process(input, processedContentItems);
 
-            Assert.Equal(plainHtml + $"<div>{message}</div>", result);
+            Assert.Equal(plainHtml + $"<div>{typeof(UnretrievedContentItem)}</div>", result);
         }
 
         [Fact]
         public void ContentItemWithoutModelIsResolvedByUnknownItemProcessor()
         {
             const string insertedContentName = "dummyCodename1";
-            const string message = "Item with no model detected";
             var insertedObject = GetContentItemObjectElement(insertedContentName);
             var wrapperWithObject = WrapElementWithDivs(insertedObject);
             var plainHtml = "<p>Lorem ipsum etc..<a>asdf</a>..</p>";
@@ -347,12 +343,13 @@ namespace KenticoCloud.Delivery.Tests
             {
                 {insertedContentName, null}
             };
-            var unknownContentItemResolver = new UnknownItemsMessageReturningResolver(message);
-            var inlineContentItemsProcessor = InlineContentItemsProcessorFactory.WithResolver(unknownContentItemResolver).Build();
+            var inlineContentItemsProcessor = InlineContentItemsProcessorFactory
+                .WithResolver(factory => factory.ResolveToType<UnknownContentItem>(acceptNull: true))
+                .Build();
 
             var result = inlineContentItemsProcessor.Process(input, processedContentItems);
 
-            Assert.Equal(plainHtml + $"<div>{message}</div>", result);
+            Assert.Equal(plainHtml + $"<div>{typeof(UnknownContentItem)}</div>", result);
         }
 
         [Fact]
@@ -365,11 +362,12 @@ namespace KenticoCloud.Delivery.Tests
             var input = plainHtml + wrapperWithObject;
             var processedContentItems = new Dictionary<string, object>
             {
-                {insertedContentName, new DummyProcessedContentItem()}
+                {insertedContentName, new DummyItem()}
             };
-            var differentResolver = new DummyImageResolver();
-            var defaultResolver = new MessageReturningResolver(message);
-            var inlineContentItemsProcessor = InlineContentItemsProcessorFactory.WithResolver(defaultResolver).AndResolver(differentResolver).Build();
+            var inlineContentItemsProcessor = InlineContentItemsProcessorFactory
+                .WithResolver(factory => factory.ResolveByDefaultToMessage(message))
+                .AndResolver(ResolveDummyImageToImg)
+                .Build();
 
             var result = inlineContentItemsProcessor.Process(input, processedContentItems);
 
@@ -386,10 +384,10 @@ namespace KenticoCloud.Delivery.Tests
             const string insertedContentItemValue = "dummyValue";
             var processedContentItems = new Dictionary<string, object>
             {
-                {insertedContentName, new DummyProcessedContentItem() {Value = insertedContentItemValue}}
+                {insertedContentName, new DummyItem {Value = insertedContentItemValue}}
             };
             var inlineContentItemsProcessor = InlineContentItemsProcessorFactory
-                .WithResolver<DummyProcessedContentItem, ResolverReturningTextAndElement>()
+                .WithResolver(factory => factory.ResolveTo<DummyItem>(item => $"Text text brackets ( &lt; [ <span>{item.Value}</span><div></div>&amp; Some more text"))
                 .Build();
 
             var result = inlineContentItemsProcessor.Process(inputHtml, processedContentItems);
@@ -405,19 +403,24 @@ namespace KenticoCloud.Delivery.Tests
             const string insertedContentName = "dummyCodename1";
             var wrapperWithObject = GetContentItemObjectElement(insertedContentName);
 
-            var inputHtml = $"A hyper-hybrid socialization &amp; turbocharges adaptive {wrapperWithObject} frameworks by thinking outside of the box, while the support structures influence the mediators.";
+            var inputHtml = 
+                $"A hyper-hybrid socialization &amp; turbocharges adaptive {wrapperWithObject} frameworks"
+                + " by thinking outside of the box, while the support structures influence the mediators.";
             const string insertedContentItemValue = "dummyValue";
             var processedContentItems = new Dictionary<string, object>
             {
-                {insertedContentName, new DummyProcessedContentItem {Value = insertedContentItemValue}}
+                {insertedContentName, new DummyItem {Value = insertedContentItemValue}}
             };
             var inlineContentItemsProcessor = InlineContentItemsProcessorFactory
-                .WithResolver<DummyProcessedContentItem, ResolverReturningIncorrectHtml>()
+                .WithResolver(factory => factory.ResolveTo<DummyItem>(_ => "<![CDATA[ test ]]>"))
                 .Build();
 
             var result = inlineContentItemsProcessor.Process(inputHtml, processedContentItems);
 
-            var expectedResults = "A hyper-hybrid socialization &amp; turbocharges adaptive [Inline content item resolver provided an invalid HTML 5 fragment (1:3). Please check the output for a content item dummyCodename1 of type KenticoCloud.Delivery.Tests.ContentItemsInRichTextProcessorTests+DummyProcessedContentItem.] frameworks by thinking outside of the box, while the support structures influence the mediators.";
+            var expectedResults = 
+                "A hyper-hybrid socialization &amp; turbocharges adaptive [Inline content item resolver provided an invalid HTML 5 fragment (1:3)."
+                + $" Please check the output for a content item dummyCodename1 of type {typeof(DummyItem).FullName}.]"
+                + " frameworks by thinking outside of the box, while the support structures influence the mediators.";
 
             Assert.Equal(expectedResults, result);
         }
@@ -479,13 +482,11 @@ namespace KenticoCloud.Delivery.Tests
             var input = plainHtml + wrapperWithObject;
             var processedContentItems = new Dictionary<string, object>
             {
-                {insertedContentName, new DummyProcessedContentItem()}
+                {insertedContentName, new DummyItem()}
             };
-            var differentResolver = new MessageReturningResolver("this should not appear");
-            var defaultResolver = new MessageReturningResolver(message);
             var inlineContentItemsProcessor = InlineContentItemsProcessorFactory
-                .WithResolver(differentResolver)
-                .AndResolver(defaultResolver)
+                .WithResolver(factory => factory.ResolveByDefaultToMessage("this should not appear"))
+                .AndResolver(factory => factory.ResolveByDefaultToMessage(message))
                 .Build();
 
             var result = inlineContentItemsProcessor.Process(input, processedContentItems);
@@ -493,118 +494,26 @@ namespace KenticoCloud.Delivery.Tests
             Assert.Equal(plainHtml + $"<div>{message}</div>", result);
         }
 
+        private static IInlineContentItemsResolver<DummyImageItem> ResolveDummyImageToImg(InlineContentItemsResolverFactory factory)
+            => factory.ResolveTo<DummyImageItem>(item => $"<img src=\"{item.Source}\" />");
 
+        private static IInlineContentItemsResolver<DummyItem> ResolveDummyItemToSpan(InlineContentItemsResolverFactory factory)
+            => factory.ResolveTo<DummyItem>(item => $"<span>{item.Value}</span>");
 
-        private class DummyResolver : IInlineContentItemsResolver<DummyProcessedContentItem>
-        {
-            public int callsForResolve;
-            public string Resolve(ResolvedContentItemData<DummyProcessedContentItem> item)
-            {
-                callsForResolve++;
-                return string.Empty;
-            }
-        }
+        private static string GetContentItemObjectElement(string insertedContentName)
+            => $"<object type=\"{ContentItemType}\" data-type=\"{ContentItemDataType}\" data-codename=\"{insertedContentName}\"></object/>";
 
-        private class DummyProcessedContentItem
+        private static string WrapElementWithDivs(string insertedObject)
+            => "<div>" + insertedObject + "</div>";
+
+        private class DummyItem
         {
             public string Value { get; set; }
         }
 
-        private class DummyImageContentItem
+        private class DummyImageItem
         {
             public string Source { get; set; }
-        }
-
-        private class ResolverReturningValue : IInlineContentItemsResolver<DummyProcessedContentItem>
-        {
-            public string Resolve(ResolvedContentItemData<DummyProcessedContentItem> data)
-            {
-                return data.Item?.Value ?? string.Empty;
-            }
-        }
-
-        private class DummyImageResolver : IInlineContentItemsResolver<DummyImageContentItem>
-        {
-            public string Resolve(ResolvedContentItemData<DummyImageContentItem> data)
-            {
-                return $"<img src=\"{data.Item.Source}\" />";
-            }
-        }
-
-        private class ResolverReturningElement : IInlineContentItemsResolver<DummyProcessedContentItem>
-        {
-            public string Resolve(ResolvedContentItemData<DummyProcessedContentItem> data)
-            {
-                return $"<span>{data.Item.Value}</span>";
-            }
-        }
-
-        private class ResolverReturningTextAndElement : IInlineContentItemsResolver<DummyProcessedContentItem>
-        {
-            public string Resolve(ResolvedContentItemData<DummyProcessedContentItem> data)
-            {
-                return $"Text text brackets ( &lt; [ <span>{data.Item.Value}</span><div></div>&amp; Some more text";
-            }
-        }
-
-        private class ResolverReturningIncorrectHtml : IInlineContentItemsResolver<DummyProcessedContentItem>
-        {
-            public string Resolve(ResolvedContentItemData<DummyProcessedContentItem> data)
-            {
-                return $"<![CDATA[ test ]]>";
-            }
-        }
-
-        private class MessageReturningResolver : IInlineContentItemsResolver<object>
-        {
-            private readonly string _message;
-
-            public MessageReturningResolver(string message)
-            {
-                _message = message;
-            }
-            public string Resolve(ResolvedContentItemData<object> item)
-            {
-                return _message;
-            }
-        }
-
-        private class UnretrievedItemsMessageReturningResolver : IInlineContentItemsResolver<UnretrievedContentItem>
-        {
-            private readonly string _message;
-
-            public UnretrievedItemsMessageReturningResolver(string message)
-            {
-                _message = message;
-            }
-            public string Resolve(ResolvedContentItemData<UnretrievedContentItem> item)
-            {
-                return _message;
-            }
-        }
-
-        private class UnknownItemsMessageReturningResolver : IInlineContentItemsResolver<UnknownContentItem>
-        {
-            private readonly string _message;
-
-            public UnknownItemsMessageReturningResolver(string message)
-            {
-                _message = message;
-            }
-            public string Resolve(ResolvedContentItemData<UnknownContentItem> data)
-            {
-                return _message;
-            }
-        }
-
-        private static string GetContentItemObjectElement(string insertedContentName)
-        {
-            return $"<object type=\"{ContentItemType}\" data-type=\"{ContentItemDataType}\" data-codename=\"{insertedContentName}\"></object/>";
-        }
-
-        private static string WrapElementWithDivs(string insertedObject)
-        {
-            return "<div>" + insertedObject + "</div>";
         }
     }
 }

--- a/KenticoCloud.Delivery.Tests/DeliveryClientTests.cs
+++ b/KenticoCloud.Delivery.Tests/DeliveryClientTests.cs
@@ -901,8 +901,10 @@ namespace KenticoCloud.Delivery.Tests
 
             var deliveryClient = DeliveryClientBuilder
                 .WithProjectId(_guid)
-                .WithInlineContentItemsResolver(InlineContentItemsResolverFactory.CreateTweetResolver(tweetPrefix))
-                .WithInlineContentItemsResolver(InlineContentItemsResolverFactory.CreateHostedVideoResolver(hostedVideoPrefix))
+                .WithInlineContentItemsResolver(InlineContentItemsResolverFactory.Instance
+                    .ResolveTo<Tweet>(tweet => tweetPrefix + tweet.TweetLink))
+                .WithInlineContentItemsResolver(InlineContentItemsResolverFactory.Instance
+                    .ResolveTo<HostedVideo>(video => hostedVideoPrefix + video.VideoHost.First().Name))
                 .WithCodeFirstTypeProvider(new CustomTypeProvider())
                 .WithHttpClient(_mockHttp.ToHttpClient())
                 .Build();

--- a/KenticoCloud.Delivery.Tests/DependencyInjectionFrameworks/Helpers/DependencyInjectionFrameworksHelper.cs
+++ b/KenticoCloud.Delivery.Tests/DependencyInjectionFrameworks/Helpers/DependencyInjectionFrameworksHelper.cs
@@ -22,7 +22,7 @@ namespace KenticoCloud.Delivery.Tests.DependencyInjectionFrameworks.Helpers
 
         internal static IServiceCollection RegisterInlineContentItemResolvers(this IServiceCollection serviceCollection)
             => serviceCollection
-                .AddDeliveryInlineContentItemsResolver(InlineContentItemsResolverFactory.CreateHostedVideoResolver(null))
+                .AddDeliveryInlineContentItemsResolver(InlineContentItemsResolverFactory.Instance.ResolveToMessage<HostedVideo>(string.Empty))
                 .AddDeliveryInlineContentItemsResolver<Tweet, FakeTweetResolver>();
 
         internal static IServiceProvider BuildAutoFacServiceProvider(this IServiceCollection serviceCollection)

--- a/KenticoCloud.Delivery.Tests/Extensions/FakeServiceCollection.cs
+++ b/KenticoCloud.Delivery.Tests/Extensions/FakeServiceCollection.cs
@@ -127,7 +127,7 @@ namespace KenticoCloud.Delivery.Tests.Extensions
         /// These are supposed to be primarily used by <see cref="InlineContentItemProcessor"/> only.
         /// </summary>
         /// <returns>
-        /// Null for typless resolvers since we want to check their registration via
+        /// Null for typeless resolvers since we want to check their registration via
         /// <see cref="ContentTypesResolvedByResolvers"/> rather than container registrations
         /// (since there is no way to obtain its content item type unless instantiated)
         /// </returns>

--- a/KenticoCloud.Delivery.Tests/Extensions/ServiceCollectionsExtensionsTests.cs
+++ b/KenticoCloud.Delivery.Tests/Extensions/ServiceCollectionsExtensionsTests.cs
@@ -112,8 +112,8 @@ namespace KenticoCloud.Delivery.Tests.Extensions
         [Fact]
         public void AddDeliveryInlineContentItemsResolver_RegistersTheResolverImplementation()
         {
-            var tweetResolver = InlineContentItemsResolverFactory.CreateTweetResolver(null);
-            var hostedVideoResolver = InlineContentItemsResolverFactory.CreateHostedVideoResolver(null);
+            var tweetResolver = InlineContentItemsResolverFactory.Instance.ResolveToMessage<Tweet>("Tweet");
+            var hostedVideoResolver = InlineContentItemsResolverFactory.Instance.ResolveToMessage<HostedVideo>("HostedVideo");
             var expectedRegisteredTypes = AddToExpectedInterfacesWithImplementationTypes(
                 (typeof(IInlineContentItemsResolver<Tweet>), tweetResolver.GetType()),
                 (typeof(IInlineContentItemsResolver<HostedVideo>), hostedVideoResolver.GetType()));

--- a/KenticoCloud.Delivery.Tests/Factories/InlineContentItemsResolverFactory.cs
+++ b/KenticoCloud.Delivery.Tests/Factories/InlineContentItemsResolverFactory.cs
@@ -24,6 +24,9 @@ namespace KenticoCloud.Delivery.Tests.Factories
                 ? typeof(TContentItem).FullName 
                 : item.GetType().FullName);
 
+        public IInlineContentItemsResolver<object> ResolveByDefaultToType()
+            => ResolveToType<object>();
+
         public IInlineContentItemsResolver<TContentItem> ResolveTo<TContentItem>(Func<TContentItem, string> resultSelector)
             => new SimpleResolver<TContentItem>(resultSelector);
 

--- a/KenticoCloud.Delivery/InlineContentItems/InlineContentItemsProcessor.cs
+++ b/KenticoCloud.Delivery/InlineContentItems/InlineContentItemsProcessor.cs
@@ -102,19 +102,16 @@ namespace KenticoCloud.Delivery.InlineContentItems
                 return inlineContentItemResolver(inlineContentItem);
             }
 
-            var data = new ResolvedContentItemData<object> { Item = inlineContentItem };
             if (_inlineContentItemsResolvers.TryGetValue(typeof(object), out var defaultContentItemResolver))
             {
-                return defaultContentItemResolver(data);
+                return defaultContentItemResolver(inlineContentItem);
             }
 
             return "Default inline content item resolver for non specific content type was not registered.";
         }
 
         private static Type GetInlineContentItemType(object inlineContentItem)
-        {
-            return inlineContentItem?.GetType() ?? typeof(UnknownContentItem);
-        }
+            => inlineContentItem?.GetType() ?? typeof(UnknownContentItem);
 
         private void ReplaceElementWithFragmentNodes(AngleSharp.Dom.Html.IHtmlDocument document, IElement inlineContentItemElement, string contentItemCodename, object inlineContentItem, string fragmentText)
         {

--- a/KenticoCloud.Delivery/InlineContentItems/RichTextContentElements.cs
+++ b/KenticoCloud.Delivery/InlineContentItems/RichTextContentElements.cs
@@ -5,8 +5,14 @@ namespace KenticoCloud.Delivery.InlineContentItems
     /// </summary>
     internal struct RichTextContentElements
     {
-        public string ContentItemCodeName { get; set; }
+        public string ContentItemCodeName { get; }
 
-        public string RichTextElementCodeName { get; set; }
+        public string RichTextElementCodeName { get; }
+
+        public RichTextContentElements(string contentItemCodeName, string richTextElementCodeName)
+        {
+            RichTextElementCodeName = richTextElementCodeName;
+            ContentItemCodeName = contentItemCodeName;
+        }
     }
 }


### PR DESCRIPTION
### Motivation

Fixes #153

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [ ] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

I suggest going through the scenario described in #153 and quickly check that [cloud-sample-app-net](https://github.com/Kentico/cloud-sample-app-net) would work as expected.
