### PR TITLE
Update circleci image to mcr.microsoft.com/dotnet/core/sdk:2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: microsoft/aspnetcore-build:2.0
+      - image: mcr.microsoft.com/dotnet/core/sdk:2.1
     steps:
       - checkout
       - run:


### PR DESCRIPTION
`microsoft/aspnetcore-build:2.0` was deprecated and replaced with `mcr.microsoft.com/dotnet/core/sdk:2.1`


https://github.com/aspnet/aspnet-docker/tree/master/2.1