### PR TITLE
Set implicit SDK version header while using Android release mode.

### DIFF
--- a/KenticoCloud.Delivery/Extensions/HttpRequestHeadersExtensions.cs
+++ b/KenticoCloud.Delivery/Extensions/HttpRequestHeadersExtensions.cs
@@ -34,8 +34,19 @@ namespace KenticoCloud.Delivery.Extensions
         private static string GetSdkVersion()
         {
             var assembly = Assembly.GetExecutingAssembly();
-            var fileVersionInfo = FileVersionInfo.GetVersionInfo(assembly.Location);
-            var sdkVersion = fileVersionInfo.ProductVersion;
+            string sdkVersion;
+
+            try
+            {
+                var fileVersionInfo = FileVersionInfo.GetVersionInfo(assembly.Location);
+                sdkVersion = fileVersionInfo.ProductVersion;
+            }
+            catch (System.IO.FileNotFoundException)
+            {
+                // Invalid Location path of assembly in Android's Xamarin release mode (unchecked "Use a shared runtime" flag)
+                // https://bugzilla.xamarin.com/show_bug.cgi?id=54678
+                sdkVersion = "0.0.0";
+            }
 
             return sdkVersion;
         }


### PR DESCRIPTION
### Motivation

Fixes https://github.com/Kentico/delivery-sdk-net/issues/160.

### Checklist

- [X] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [X] Tests are passing
- [ ] Docs have been updated (if applicable)
- [X] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Manual testing on Android device in release mode.
